### PR TITLE
Removed the quotation marks because they produce errors on Windows

### DIFF
--- a/src/continuation/ContinuationStealTests.kt
+++ b/src/continuation/ContinuationStealTests.kt
@@ -23,7 +23,7 @@ class ContinuationStealTests {
     }
 
     @Test
-    fun `At the beginning function says "Before"`() = runBlockingTest {
+    fun `At the beginning function says Before`() = runBlockingTest {
         val fakeConsole = FakeConsole()
         val job = launch {
             continuationSteal(fakeConsole)
@@ -34,7 +34,7 @@ class ContinuationStealTests {
     }
 
     @Test
-    fun `At the end function says "After"`() = runBlockingTest {
+    fun `At the end function says After`() = runBlockingTest {
         val fakeConsole = FakeConsole()
         val job = launch {
             continuationSteal(fakeConsole)
@@ -64,7 +64,7 @@ class ContinuationStealTests {
     }
 
     @Test
-    fun `Only "Before" is printed before resume`() = runBlockingTest {
+    fun `Only Before is printed before resume`() = runBlockingTest {
         val fakeConsole = FakeConsole()
         val job = launch {
             continuationSteal(fakeConsole)


### PR DESCRIPTION
In preparation for your workshop on Tuesday & Friday, I realized that the `ContinuationStealTests.kt` was throwing an odd message, `Permission denied`.

I took a look at the test itself and find out that the problem is, that on Windows using the quotation marks with the backticks function could produce errors.